### PR TITLE
fixes to restore browser

### DIFF
--- a/src/bconnectionwizard.cpp
+++ b/src/bconnectionwizard.cpp
@@ -1901,6 +1901,7 @@ void ConfigPreviewPage::updateConfigs()
     consoleConfig += QString("  PoolAcl = *all*\n");
     consoleConfig += QString("  FileSetAcl = *all*\n");
     consoleConfig += QString("  CatalogAcl = *all*\n");
+    consoleConfig += QString("  WhereAcl = *all*\n");
     consoleConfig += QString("}\n");
 
     m_consoleConfigEdit->setPlainText(consoleConfig);

--- a/src/director/bareosdirector.cpp
+++ b/src/director/bareosdirector.cpp
@@ -1762,7 +1762,7 @@ const QString BareosDirector::commandToString(Command cmd, const QString &args)
     case Command::Rerun:            command = QString("rerun jobid=%1").arg(args); break;
 
     // Restore
-    case Command::Restore:          command = "restore"; break;
+    case Command::Restore:          command = QString("restore %1").arg(args); break;
     case Command::RestoreAll:       command = "restore all"; break;
     case Command::RestoreSelect:    command = "restore select"; break;
 

--- a/src/director/bareosdirector.cpp
+++ b/src/director/bareosdirector.cpp
@@ -1696,7 +1696,7 @@ const QString BareosDirector::commandToString(Command cmd, const QString &args)
     case Command::ApiMode:
         // ✅ Intelligente API-Modus-Verarbeitung
         if (args.isEmpty()) {
-            command = ".api 1";  // Default: JSON
+            command = ".api json compact=yes";  // Default: JSON
         } else {
             bool ok;
             int mode = args.toInt(&ok);

--- a/src/jobs/brestorewizard.cpp
+++ b/src/jobs/brestorewizard.cpp
@@ -614,7 +614,7 @@ void BRestorePreviewPage::initializePage()
 
     // Build .bvfs_restore command
     QStringList parts;
-    parts << QString(".bvfs_restore path=%1").arg(data->restoreTableName);
+    parts << QString("path=%1").arg(data->restoreTableName);
     parts << QString("jobid=%1").arg(data->resolvedBvfsJobIds);
     if (!fileIds.isEmpty()) {
         parts << QString("fileid=%1").arg(fileIds);
@@ -625,7 +625,10 @@ void BRestorePreviewPage::initializePage()
     data->bvfsRestoreCommand = parts.join(" ");
 
     // Build restore command
-    data->restoreCommand = QString("restore file=?%1 client=%2 where=%3 replace=%4 done yes")
+    // Other useful options:
+    // restorejob=
+    // restoreclient=
+    data->restoreCommand = QString("file=?%1 client=%2 where=%3 replace=%4 yes")
                                .arg(data->restoreTableName)
                                .arg(data->targetClient)
                                .arg(data->restoreWhere)


### PR DESCRIPTION
The Restore Wizard has some problems.
This PR covers some of them, making it at least possible to restore full directories.

Fixed:

* .bvfs_restore command had 2x .bvfs_restore
* restore command has 2x restore, but missing the parameter
* add missing WhereAcl (otherwise restore will fail)

Still open:

- [ ] The Restore Wizard (Execute Restore) stays forever, with only the progress bar moving. This happens on success as well as on failure.
- [ ] The Restore Wizard (Execute Restore) didn't show errors. Instead the progress bar keeps moving forever.
- [ ] The Restore Wizard: when switching from "Select Files" to "Restore Options", the info about selected files is gone (0 files). (The info about selected directories is kept.) Therefore the restore command will run into a failure (.bvfs_restore will return an error).
- [ ] .bvfs_get_jobids should used without the `all` keyword (if I remember correctly, this is only used when it should check all filesets).

Newly introduced:

- [ ] fixed the restore commands did break the preview window. 

I submitted this info as PR, as it at least solves some problems. However, I fear, I'll not find the time to take care about the remaining problems.